### PR TITLE
Use a static test website to test navigation

### DIFF
--- a/src/test/scala/zio/selenium/NavigateSpec.scala
+++ b/src/test/scala/zio/selenium/NavigateSpec.scala
@@ -25,7 +25,7 @@ object NavigateSpec extends SharedWebDriverSpec {
       test("Navigate can go back") {
         for {
           _   <- WebDriver.get(trueWebsite)
-          _   <- WebDriver.get("https://duckduckgo.com/")
+          _   <- WebDriver.get(testWebsite)
           _   <- WebDriver.Navigate.back
           url <- WebDriver.getCurrentUrl
         } yield assertTrue(url == trueWebsite)


### PR DESCRIPTION
This change is aiming at `NavigateSpec` especially the `Navigate can go back` test. It seems like the test is failing non-deterministically given that the real destination could be redirecting the request from the test to anywhere. Hence, this PR aims to switch the destination website to be the one in our control. This results in the test to becoming deterministic.